### PR TITLE
Improve info cell node

### DIFF
--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -23,7 +23,7 @@ public class Config: Wall.Config {
     public var readySection = ReadySection()
 
     public struct Info {
-      public var verticalPadding: CGFloat = 10
+      public var verticalPadding: CGFloat = 20
       public var title = Title()
       public var text = Text()
       public var divider = Divider()
@@ -62,7 +62,7 @@ public class Config: Wall.Config {
 
     public struct ReadySection {
       public var horizontalPadding: CGFloat = 40
-      public var verticalPadding: CGFloat = 10
+      public var verticalPadding: CGFloat = 20
       public var text = Text()
       public var divider = Divider()
 

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -26,6 +26,7 @@ public class Config: Wall.Config {
       public var verticalPadding: CGFloat = 10
       public var title = Title()
       public var text = Text()
+      public var divider = Divider()
 
       public struct Title {
         public var textAttributes = [
@@ -49,6 +50,13 @@ public class Config: Wall.Config {
             return style
             }()
         ]
+      }
+
+      public struct Divider {
+        public var horizontalPadding: CGFloat = 10
+        public var enabled = true
+        public var height: CGFloat = 1
+        public var backgroundColor = UIColor.lightGrayColor()
       }
     }
 

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -56,7 +56,7 @@ public class Config: Wall.Config {
         public struct Icon {
           public var enabled = true
           public var padding: CGFloat = 10
-          public var size = CGSize(width: 18, height: 18)
+          public var size = CGSize(width: 24, height: 24)
           public var placeholderColor = UIColor.lightGrayColor()
           public var image: UIImage?
         }

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -41,6 +41,8 @@ public class Config: Wall.Config {
       }
 
       public struct Text {
+        public var icon = Icon()
+
         public var textAttributes = [
           NSFontAttributeName: UIFont.italicSystemFontOfSize(14),
           NSForegroundColorAttributeName: UIColor.grayColor(),
@@ -50,6 +52,14 @@ public class Config: Wall.Config {
             return style
             }()
         ]
+
+        public struct Icon {
+          public var enabled = true
+          public var padding: CGFloat = 10
+          public var size = CGSize(width: 18, height: 18)
+          public var placeholderColor = UIColor.lightGrayColor()
+          public var image: UIImage?
+        }
       }
 
       public struct Divider {

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -44,7 +44,7 @@ public class Config: Wall.Config {
         public var icon = Icon()
 
         public var textAttributes = [
-          NSFontAttributeName: UIFont.italicSystemFontOfSize(14),
+          NSFontAttributeName: UIFont.systemFontOfSize(16),
           NSForegroundColorAttributeName: UIColor.grayColor(),
           NSParagraphStyleAttributeName: {
             var style = NSMutableParagraphStyle()

--- a/Source/Nodes/CampaignInfoCellNode.swift
+++ b/Source/Nodes/CampaignInfoCellNode.swift
@@ -9,6 +9,7 @@ public class CampaignInfoCellNode: ASCellNode {
   public var config: Config?
 
   var titleNode: ASTextNode?
+  var iconNode: ASImageNode?
   var textNode: ASTextNode?
   var divider: ASDisplayNode?
 
@@ -30,6 +31,14 @@ public class CampaignInfoCellNode: ASCellNode {
           string: title,
           attributes: infoConfig.title.textAttributes)
         addSubnode(titleNode)
+      }
+
+      if infoConfig.text.icon.enabled {
+        iconNode = ASImageNode()
+        iconNode!.backgroundColor = infoConfig.text.icon.placeholderColor
+        iconNode!.image = infoConfig.text.icon.image
+
+        addSubnode(iconNode)
       }
 
       if let text = post.text {
@@ -64,11 +73,10 @@ public class CampaignInfoCellNode: ASCellNode {
         height += size.height + infoConfig.verticalPadding
       }
 
-      if let textNode = textNode {
-        let size = textNode.measure(CGSize(
-          width: width,
-          height: CGFloat(FLT_MAX)))
-        height += size.height + infoConfig.verticalPadding
+      var rowHeight = textRowHeight()
+
+      if rowHeight > 0 {
+        height += rowHeight + infoConfig.verticalPadding
       }
 
       if let divider = divider {
@@ -94,12 +102,35 @@ public class CampaignInfoCellNode: ASCellNode {
         y += size.height + padding
       }
 
-      if let textNode = textNode {
-        let size = textNode.calculatedSize
-        textNode.frame = CGRect(
-          x: 0, y: y,
-          width: width, height: size.height)
-        y += size.height + padding
+      let rowHeight = textRowHeight()
+      if rowHeight > 0 {
+        if let textNode = textNode {
+          let size = textNode.calculatedSize
+          var rowX = (width - size.width) / CGFloat(2)
+
+          if let iconNode = iconNode {
+            let iconWidth = infoConfig.text.icon.padding
+              + infoConfig.text.icon.size.width
+            rowX -= iconWidth / CGFloat(2)
+
+            let size = infoConfig.text.icon.size
+            iconNode.frame = CGRect(
+              x: rowX,
+              y: y + (rowHeight - size.height) / CGFloat(2),
+              width: size.width,
+              height: size.height)
+
+            rowX += iconWidth
+          }
+
+          textNode.frame = CGRect(
+            x: rowX,
+            y: y + (rowHeight - size.height) / CGFloat(2),
+            width: size.width,
+            height: size.height)
+
+          y += rowHeight + padding
+        }
       }
 
       if let divider = divider {
@@ -110,5 +141,30 @@ public class CampaignInfoCellNode: ASCellNode {
           height: infoConfig.divider.height)
       }
     }
+  }
+
+  // MARK: - Private methods
+
+  private func textRowHeight() -> CGFloat {
+    var rowHeight: CGFloat = 0
+
+    if let config = config {
+      let infoConfig = config.campaign.info
+
+      if let textNode = textNode {
+        let size = textNode.measure(CGSize(
+          width: width,
+          height: CGFloat(FLT_MAX)))
+        rowHeight = size.height
+      }
+
+      if let iconNode = iconNode {
+        if infoConfig.text.icon.size.height > rowHeight {
+          rowHeight = infoConfig.text.icon.size.height
+        }
+      }
+    }
+
+    return rowHeight
   }
 }

--- a/Source/Nodes/CampaignInfoCellNode.swift
+++ b/Source/Nodes/CampaignInfoCellNode.swift
@@ -10,6 +10,7 @@ public class CampaignInfoCellNode: ASCellNode {
 
   var titleNode: ASTextNode?
   var textNode: ASTextNode?
+  var divider: ASDisplayNode?
 
   // MARK: - Initialization
 
@@ -38,6 +39,12 @@ public class CampaignInfoCellNode: ASCellNode {
           attributes: infoConfig.text.textAttributes)
         addSubnode(textNode)
       }
+
+      if infoConfig.divider.enabled {
+        divider = ASDisplayNode()
+        divider!.backgroundColor = infoConfig.divider.backgroundColor
+        addSubnode(divider)
+      }
     }
   }
 
@@ -62,6 +69,10 @@ public class CampaignInfoCellNode: ASCellNode {
           width: width,
           height: CGFloat(FLT_MAX)))
         height += size.height + infoConfig.verticalPadding
+      }
+
+      if let divider = divider {
+        height += infoConfig.divider.height + infoConfig.verticalPadding
       }
     }
 
@@ -88,6 +99,15 @@ public class CampaignInfoCellNode: ASCellNode {
         textNode.frame = CGRect(
           x: 0, y: y,
           width: width, height: size.height)
+        y += size.height + padding
+      }
+
+      if let divider = divider {
+        let dividerWidth = width - 2 * infoConfig.divider.horizontalPadding
+        divider.frame = CGRect(
+          x: infoConfig.divider.horizontalPadding, y: y,
+          width: dividerWidth,
+          height: infoConfig.divider.height)
       }
     }
   }

--- a/Source/Nodes/CampaignReadyCellNode.swift
+++ b/Source/Nodes/CampaignReadyCellNode.swift
@@ -83,7 +83,7 @@ public class CampaignReadyCellNode: ASCellNode {
       if let divider = divider {
         let dividerWidth = width - 2 * sectionConfig.divider.horizontalPadding
         divider.frame = CGRect(
-          x: config.wall.post.horizontalPadding, y: y,
+          x: sectionConfig.divider.horizontalPadding, y: y,
           width: dividerWidth,
           height: sectionConfig.divider.height)
         y += padding


### PR DESCRIPTION
1. Add possibility to add icon before the text.
2. Add bottom divider.
   ![ios simulator screen shot 15 jun 2015 14 06 26](https://cloud.githubusercontent.com/assets/10529867/8159508/b4a1f3d6-1367-11e5-9ef5-7799dd4832dd.png)
